### PR TITLE
fs::path benutzt wchar in neueren versionen, #ifdef eingefuegt.

### DIFF
--- a/sequential_read/Loaders.cpp
+++ b/sequential_read/Loaders.cpp
@@ -20,7 +20,11 @@ std::optional<fs::path> prepareDataPath()
 	fs::path dataPath = parentPath.parent_path() / "Data" / "berlin_infos.dat";
 	if( !fs::exists(dataPath))
 	{
-		std::cerr << "'" << dataPath.c_str() << "' not found\n";
+#if _MSC_VER>1900 //im vs2017 ist fs::path::value_type ein char .. irgendwo danach aber wchar!
+			std::wcerr << "'" << dataPath.c_str() << "' not found\n";
+#else
+			std::cerr << "'" << dataPath.c_str() << "' not found\n";
+#endif
 		return {};
 	}
 	return dataPath;


### PR DESCRIPTION
vs2020 vs vs2017